### PR TITLE
adds npmignore to ensure the lib folder is being published

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+node_modules
+coverage


### PR DESCRIPTION
As I am quite new to npm I forgot to create a .npmignore to prevent npm from using .gitignore and therefore ignoring the lib folder when publishing.
Please merge this as 0.3.1 (0.3.0 is unusable).
Sorry for the mistake. 