### PR TITLE
Dispatch actions internally

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,18 @@ export default function configureStore() {
     path: '/todos',
     db,
     actions: {
-      remove: doc => store.dispatch({type: types.DELETE_TODO, id: doc._id}),
-      insert: doc => store.dispatch({type: types.INSERT_TODO, todo: doc}),
-      update: doc => store.dispatch({type: types.UPDATE_TODO, todo: doc}),
+      remove: doc => { return { type: types.DELETE_TODO, id: doc._id } },
+      insert: doc => { return { type: types.INSERT_TODO, todo: doc } },
+      update: doc => { return { type: types.UPDATE_TODO, todo: doc } },
     }
   })
-  const createStoreWithMiddleware = applyMiddleware(pouchMiddleware)(createStore)
-  const store = createStoreWithMiddleware(rootReducer)
+
+  const store = createStore(
+    rootReducer,
+    undefined,
+    applyMiddleware(pouchMiddleware)
+  )
+
   return store
 }
 ```
@@ -66,9 +71,9 @@ Example of a path spec:
   path: '/todos',
   db,
   actions: {
-    remove: doc => store.dispatch({type: types.DELETE_TODO, id: doc._id}),
-    insert: doc => store.dispatch({type: types.INSERT_TODO, todo: doc}),
-    update: doc => store.dispatch({type: types.UPDATE_TODO, todo: doc}),
+    remove: doc => { return { type: types.DELETE_TODO, id: doc._id } },
+    insert: doc => { return { type: types.INSERT_TODO, todo: doc } },
+    update: doc => { return { type: types.UPDATE_TODO, todo: doc } },
   }
 }
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,10 +44,10 @@ function createPouchMiddleware(_paths) {
     return spec;
   });
 
-  function listen(path) {
+  function listen(path, dispatch) {
     var changes = path.db.changes({ live: true, include_docs: true });
     changes.on('change', function (change) {
-      return onDbChange(path, change);
+      return onDbChange(path, change, dispatch);
     });
   }
 
@@ -84,20 +84,22 @@ function createPouchMiddleware(_paths) {
     });
   }
 
-  function propagateDelete(doc) {
-    this.actions.remove(doc);
+  function propagateDelete(doc, dispatch) {
+    dispatch(this.actions.remove(doc));
   }
 
-  function propagateInsert(doc) {
-    this.actions.insert(doc);
+  function propagateInsert(doc, dispatch) {
+    dispatch(this.actions.insert(doc));
   }
 
-  function propagateUpdate(doc) {
-    this.actions.update(doc);
+  function propagateUpdate(doc, dispatch) {
+    dispatch(this.actions.update(doc));
   }
 
   return function (options) {
-    paths.forEach(listen);
+    paths.forEach(function (path) {
+      return listen(path, options.dispatch);
+    });
 
     return function (next) {
       return function (action) {
@@ -144,7 +146,7 @@ function differences(oldDocs, newDocs) {
   return result;
 }
 
-function onDbChange(path, change) {
+function onDbChange(path, change, dispatch) {
   var changeDoc = change.doc;
 
   if (path.changeFilter && !path.changeFilter(changeDoc)) {
@@ -154,15 +156,15 @@ function onDbChange(path, change) {
   if (changeDoc._deleted) {
     if (path.docs[changeDoc._id]) {
       delete path.docs[changeDoc._id];
-      path.propagateDelete(changeDoc);
+      path.propagateDelete(changeDoc, dispatch);
     }
   } else {
     var oldDoc = path.docs[changeDoc._id];
     path.docs[changeDoc._id] = changeDoc;
     if (oldDoc) {
-      path.propagateUpdate(changeDoc);
+      path.propagateUpdate(changeDoc, dispatch);
     } else {
-      path.propagateInsert(changeDoc);
+      path.propagateInsert(changeDoc, dispatch);
     }
   }
 }

--- a/test/with-redux.js
+++ b/test/with-redux.js
@@ -30,9 +30,9 @@ describe('Pouch Redux Middleware', function() {
       path: '/todos',
       db: db,
       actions: {
-        remove: doc => store.dispatch({type: actionTypes.DELETE_TODO, id: doc._id}),
-        insert: doc => store.dispatch({type: actionTypes.INSERT_TODO, todo: doc}),
-        update: doc => store.dispatch({type: actionTypes.UPDATE_TODO, todo: doc}),
+        remove: (doc) => { return {type: actionTypes.DELETE_TODO, id: doc._id} },
+        insert: (doc) => { return {type: actionTypes.INSERT_TODO, todo: doc} },
+        update: (doc) => { return {type: actionTypes.UPDATE_TODO, todo: doc} }
       },
       changeFilter: doc => !doc.filter
     });


### PR DESCRIPTION
It would make things easier and cleaner if path spec action hooks returned
action objects and the middleware dispatched them internally:

    actions: {
      remove: doc => { return { type: types.DELETE_TODO, id: doc._id } },
      insert: doc => { return { type: types.INSERT_TODO, todo: doc } },
      update: doc => { return { type: types.UPDATE_TODO, todo: doc } }
    }

[Redux middlewares receive store's dispatch method](http://redux.js.org/docs/api/applyMiddleware.html#arguments), so instead of
manually dispatching actions to store in action functions, we can
return the action and let the middleware dispatch them.

Also, instead of

    const createStoreWithMiddleware = applyMiddleware(pouchMiddleware)(createStore)
    const store = createStoreWithMiddleware(rootReducer)

we can do

    const store = createStore(
      rootReducer,
      undefined,
      applyMiddleware(pouchMiddleware)
    )

which IMO is, more concise and [a lot](https://github.com/reactjs/redux/blob/master/examples/real-world/store/configureStore.prod.js) [more](https://github.com/reactjs/redux/blob/master/examples/async/store/configureStore.js) [similar](https://github.com/reactjs/redux/blob/64a8c66b454163660f9d49bcce92a3230cdbcb2a/examples/shopping-cart/index.js) to official Redux examples.