### PR TITLE
add initialBatchDispatched callback on paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ multiple paths in a single database that are differentiated through an attribute
 which is useful when metadata is needed or errors need custom handling.
 Arguments are `error, data, callback`. `callback` must be invoked with a potential error
 after custom handling is done.
+* `initialBatchDispatched` a function that is invoked once the initial set of
+data has been read from pouchdb and dispatched to the redux store.
+This comes handy if you want skip the initial updates to a store
+subscriber by delaying the subscription to the redux store
+until the initial state is present.
 
 Example of a path spec:
 

--- a/test/with-redux.js
+++ b/test/with-redux.js
@@ -176,7 +176,7 @@ describe('Pouch Redux Middleware', function() {
           return done(err);
         }
 
-        let called = false;
+        var called = false;
         store.subscribe(() => {
           if (called) {
             done(new Error('expect subscribe to only be called once'));

--- a/test/with-redux.js
+++ b/test/with-redux.js
@@ -162,4 +162,35 @@ describe('Pouch Redux Middleware', function() {
     done();
   });
 
+  it('calles initialBatchDispatched', (done) => {
+    const anotherMiddleware = PouchMiddleware({
+      path: '/todos',
+      db: db,
+      actions: {
+        remove: (doc) => { return {type: actionTypes.DELETE_TODO, id: doc._id} },
+        insert: (doc) => { return {type: actionTypes.INSERT_TODO, todo: doc} },
+        update: (doc) => { return {type: actionTypes.UPDATE_TODO, todo: doc} }
+      },
+      initialBatchDispatched(err) {
+        if (err) {
+          return done(err);
+        }
+
+        let called = false;
+        store.subscribe(() => {
+          if (called) {
+            done(new Error('expect subscribe to only be called once'));
+          }
+          called = true;
+          expect(store.getState().todos.length).to.equal(1);
+          timers.setTimeout(done, 100);
+        });
+
+        expect(store.getState().todos.length).to.equal(2);
+        store.dispatch({type: actionTypes.DELETE_TODO, id: 'c'});
+      }
+    });
+    const store = redux.applyMiddleware(anotherMiddleware)(redux.createStore)(rootReducer);
+    expect(store.getState().todos.length).to.equal(0);
+  });
 });


### PR DESCRIPTION
if given, this function gets called once the initial batch of docs are dispatched on the redux store

fix https://github.com/pgte/pouch-redux-middleware/issues/29